### PR TITLE
feat: support custom API key on creation

### DIFF
--- a/src/admin/routes.ts
+++ b/src/admin/routes.ts
@@ -191,7 +191,7 @@ export function registerAdmin(app: Hono) {
 
   admin.post('/api-keys', async (c) => {
     const body = await c.req.json();
-    const apiKey = createApiKey(body.name);
+    const apiKey = createApiKey(body.name, body.key);
     return c.json(apiKey, 201);
   });
 

--- a/src/api-keys.ts
+++ b/src/api-keys.ts
@@ -14,9 +14,9 @@ export interface ApiKey {
 /**
  * 创建新的 API 密钥
  */
-export function createApiKey(name?: string): ApiKey {
+export function createApiKey(name?: string, customKey?: string): ApiKey {
   const id = uuidv4();
-  const key = 'sk-' + uuidv4().replace(/-/g, '');
+  const key = customKey || 'sk-' + uuidv4().replace(/-/g, '');
   const created_at = new Date().toISOString();
 
   db.prepare(


### PR DESCRIPTION
## Summary
- Allow passing an optional `key` field when creating API keys via `POST /admin/api-keys`
- If provided, use the custom key instead of auto-generating one
- Only 3 lines changed, fully backward compatible (no `key` field = auto-generate as before)

## Use case
When using mimo2api across multiple platforms/clients, it's convenient to set a consistent, memorable API key rather than managing random `sk-xxx` strings.

## Test plan
- [x] `POST /admin/api-keys` with `{"name":"test","key":"my-custom-key"}` → returns key `my-custom-key`
- [x] `POST /admin/api-keys` with `{"name":"test"}` (no key) → auto-generates `sk-xxx` as before
- [x] Custom key works for authentication in `/v1/chat/completions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)